### PR TITLE
Update omnipkg to 3.0.0 (noarch, build 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/omnipkg-feedsto
 
 Home: https://omnipkg.pages.dev/
 
-Package license: 
+Package license: AGPL-3.0-only
 
 Summary: The Ultimate Python Dependency Resolver. One environment. Infinite packages. Zero conflicts.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 8839241a1c7822c953384b6d03173a3771c23fd358a2e0b14c1dc1d15935cb79
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: 
     - export OMNIPKG_SKIP_C_EXT=1    # [unix]
@@ -60,6 +60,7 @@ test:
 
 about:
   home: https://omnipkg.pages.dev/
+  license: AGPL-3.0-only
   license_family: AGPL
   license_file: LICENSE
   summary: 'The Ultimate Python Dependency Resolver. One environment. Infinite packages. Zero conflicts.'


### PR DESCRIPTION
🤖 Automated update to omnipkg version 3.0.0 (noarch build)

**Changes:**
- ✅ Version: 3.0.0
- ✅ SHA256: 8839241a1c7822c953384b6d03173a3771c23fd358a2e0b14c1dc1d15935cb79
- ✅ Build number: 2
- ✅ Architecture: noarch
- ✅ Updated conda-forge.yml for noarch config

This PR updates the recipe for conda-forge distribution.