### PR TITLE
Update omnipkg to 3.0.0 (noarch, build 3)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 8839241a1c7822c953384b6d03173a3771c23fd358a2e0b14c1dc1d15935cb79
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: 
     - export OMNIPKG_SKIP_C_EXT=1    # [unix]


### PR DESCRIPTION
🤖 Automated update to omnipkg version 3.0.0 (noarch build)

**Changes:**
- ✅ Version: 3.0.0
- ✅ SHA256: 8839241a1c7822c953384b6d03173a3771c23fd358a2e0b14c1dc1d15935cb79
- ✅ Build number: 3
- ✅ Architecture: noarch
- ✅ Updated conda-forge.yml for noarch config

This PR updates the recipe for conda-forge distribution.