### PR TITLE
Update omnipkg to 3.2.1 (noarch, build 0)

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,19 +1,11 @@
 github:
   branch_name: main
   tooling_branch_name: main
-
 conda_build:
   error_overlinking: true
-
 conda_forge_output_validation: true
-
+# For noarch, just specify ONE build platform (typically linux_64)
+# The package will automatically work on all platforms
 provider:
-  linux_aarch64: azure
-  linux_ppc64le: azure
-  win: azure
-  osx_arm64: azure  # <--- ENABLE THIS
-
-build_platform:
-  linux_aarch64: linux_64
-  linux_ppc64le: linux_64
-  osx_arm64: osx_64  # <--- ADD THIS (Forces Cross-Compilation on Intel Runner)
+  linux: azure
+# No build_platform section needed for noarch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "omnipkg" %}
-{% set version = "3.2.0" %}
+{% set version = "3.2.1" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +8,15 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c9bfa6decc3846f80433e5f25f3e98934bad5fbd60630599d01acb7e5bffee7f
+  sha256: fdfd49ac27ce35d6853de895710f712bbcc9d2e45c3b6559f494455b9012fb59
 
 build:
-  number: 1
-  script:
-    - python -m pip install . --no-deps --no-build-isolation -vv  # [unix]
-    - python -m pip install . --no-deps --no-build-isolation -vv  # [win]
-    
+  number: 0
+  noarch: python
+  script: 
+    - export OMNIPKG_SKIP_C_EXT=1    # [unix]
+    - set OMNIPKG_SKIP_C_EXT=1       # [win]
+    - python -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - omnipkg = omnipkg.dispatcher:main
     - 8pkg = omnipkg.dispatcher:main
@@ -22,43 +24,36 @@ build:
     - OMNIPKG = omnipkg.dispatcher:main
 
 requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ stdlib("c") }}  
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
-    - python
+    - python {{ python_min }}
     - pip
-    - setuptools >=50.0,<70.0
+    - setuptools >=61.0
     - wheel
   run:
-    - python                      # Conda-forge actively supports 3.9 through 3.13
+    - python >={{ python_min }}
     - requests >=2.20
     - psutil >=5.9.0
     - typer >=0.4.0
     - rich >=10.0.0
     - filelock >=3.20.3
     - packaging >=23.0
-    - tomli >=1.0.0  # [py<311]
-    - typing_extensions >=4.0.0  # [py<310]
+    - tomli >=1.0.0
+    - typing_extensions >=4.0.0
     - authlib >=1.6.9
     - aiohttp >=3.13.5
-    - cryptography >=46.0.7  # [not ppc64le]
     - pip-audit >=2.0.0
-    - uv >=0.9.6  # [not ppc64le]
     - urllib3 >=2.6.3
     - flask >=3.0.3
-    - flask-cors >=3.0   
+    - flask-cors >=3.0
 
 test:
-  # This selector skips tests when building osx-arm64 on an Intel runner
   requires:
     - pip
+    - python {{ python_min }}
   imports:
-    - omnipkg            # [build_platform == target_platform]
+    - omnipkg
   commands:
-    - omnipkg --version  # [build_platform == target_platform]
+    - omnipkg --version
 
 about:
   home: https://omnipkg.pages.dev/
@@ -67,7 +62,7 @@ about:
   license_file: LICENSE
   summary: 'The Ultimate Python Dependency Resolver. One environment. Infinite packages. Zero conflicts.'
   description: |
-    OmniPkg is a distributed Python runtime hypervisor that enables concurrent,
+    OmniPkg is a distributed Python runtime hypervisor that enables concurrent, 
     zero-copy multi-framework orchestration across multiple Python versions and toolchains.
 
     Platform Support:
@@ -85,6 +80,10 @@ about:
     - True zero-copy tensor passing across different Python versions, PyTorch/CUDA versions, and frameworks — no JSON serialization or process boundaries required
 
     Perfect for scientific computing, large model serving, and heterogeneous Python/CUDA workflows where maximum flexibility and minimal latency matter.
+
+    Note for noarch builds:
+    - Core functionality works without the native C extension.
+    - For maximum performance (sub-ms dispatching), install the platform-specific build instead.
   doc_url: https://omnipkg.readthedocs.io/en/latest/
   dev_url: https://github.com/1minds3t/omnipkg
 


### PR DESCRIPTION
🤖 Automated update to omnipkg version 3.2.1 (noarch build)

**Changes:**
- ✅ Version: 3.2.1
- ✅ SHA256: fdfd49ac27ce35d6853de895710f712bbcc9d2e45c3b6559f494455b9012fb59
- ✅ Build number: 0
- ✅ Architecture: noarch
- ✅ Updated conda-forge.yml for noarch config

This PR updates the recipe for conda-forge distribution.