### PR TITLE
Update omnipkg to 3.3.4 (noarch, build 1)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,10 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        docker_run_args: ''
+        build_workspace_dir: build_artifacts
         store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
   variables: {}
 
@@ -26,6 +29,9 @@ jobs:
     displayName: Configure binfmt_misc
 
   - script: |
+        export MINIFORGE_HOME=$(tools_install_dir)
+        export CONDA_BLD_PATH=$(build_workspace_dir)
+        export CONDA_FORGE_DOCKER_RUN_ARGS="$(docker_run_args)"
         export CI=azure
         export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
         export remote_url=$(Build.Repository.Uri)

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 6cd2c81b84336210a3978e56b010d9b9c3dabe8067b7ef83bc6129f87fa486f2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: 
     - export OMNIPKG_SKIP_C_EXT=1    # [unix]


### PR DESCRIPTION
🤖 Automated update to omnipkg version 3.3.4 (noarch build)

**Changes:**
- ✅ Version: 3.3.4
- ✅ SHA256: 6cd2c81b84336210a3978e56b010d9b9c3dabe8067b7ef83bc6129f87fa486f2
- ✅ Build number: 1
- ✅ Architecture: noarch
- ✅ Updated conda-forge.yml for noarch config

This PR updates the recipe for conda-forge distribution.